### PR TITLE
Fixed redirection to search page after sign in and sign up

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -18,9 +18,41 @@ class ApplicationController < ActionController::Base
     redirect_to(root_path)
   end
 
-
   def devise_or_admin_controller?
     devise_controller? || params[:controller] =~ /admin\/.*/
+  end
+
+  def after_sign_in_path_for(resource)
+    url = stored_location_for(resource)
+    if url.include?("practices") && resource.has_practice
+      root_path
+    elsif url.include?("locums") && !resource.has_practice
+      root_path
+    else
+      sign_in_url = search_practices_path
+      if request.referer == sign_in_url
+        super
+      else
+        url || request.referer || root_path
+      end
+    end
+  end
+
+   def after_sign_up_path_for(resource)
+    raise
+    url = stored_location_for(resource)
+    if url.include?("practices") && resource.has_practice
+      root_path
+    elsif url.include?("locums") && !resource.has_practice
+      root_path
+    else
+      sign_in_url = search_practices_path
+      if request.referer == sign_in_url
+        super
+      else
+        url || request.referer || root_path
+      end
+    end
   end
 
   def disable_footer

--- a/app/views/calendars/show.html.erb
+++ b/app/views/calendars/show.html.erb
@@ -34,9 +34,9 @@
             <% if slot.end_date > Date.today %>
               <div class="myslots">
                 <p><strong><%= l(slot.start_date, format: "%e %B %Y") %></strong> au <strong><%= l(slot.end_date, format: "%e %B %Y") %></strong></p>
-                <div class="delete-gray">
-                  <%= link_to "X", user_slot_path(id: slot.id, user_id: current_user.id), method: :delete, data: { confirm: "Etes-vous sûr(e) ?" } %>
-                </div>
+                <%= link_to user_slot_path(id: slot.id, user_id: current_user.id), method: :delete do %>
+                  <div class="delete-gray"><strong>X</strong></div>
+                <% end %>
               </div>
             <% end %>
           <% end %>


### PR DESCRIPTION
Il y avait un bug quand en tant que visiteur sur la home page tu cherchais un "remplaçant", mais que lorsque tu te log ou que tu t'inscrivais, et que tu disais en fait chercher un "remplacement", le redirection enregistrée t'envoyait sur la mauvaise search.

J'ai corrigé ça personnalisant les ajoutant des actions Devise :
- after_sign_in_path_for(resource)
- after_sign_up_path_for(resource)
